### PR TITLE
refactor: extract validators to module scope

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -136,6 +136,8 @@ export namespace constants {
     export const DT_MAX = 13;
     export const DT_RESERVED = 11;
 
+    export const DT_UINT_32BIT_MAX = 4294967295;
+    export const DT_UINT_16BIT_MAX = 65535;
     export const DT_FLOATING_32BIT_MIN = 1.176e-38;
     export const DT_FLOATING_32BIT_MAX = 3.4028e38;
     export const DT_FLOAT64_MAX_INT = '9007199254740991';

--- a/src/validation/decorators/is_kolibri_date.ts
+++ b/src/validation/decorators/is_kolibri_date.ts
@@ -25,11 +25,15 @@ import {
 import { format } from 'date-fns';
 
 
+export function isKolibriDate(value: any) {
+    const dateString = format(new Date(value), 'yyyy-MM-dd');
+    return isDateString(value) && value === dateString;
+}
+
 @ValidatorConstraint({ name: 'isKolibriDate', async: true })
 export class IsKolibriDateConstraint implements ValidatorConstraintInterface {
     validate(date: any, _args: ValidationArguments) {
-        const dateString = format(new Date(date), 'yyyy-MM-dd');
-        return isDateString(date) && date === dateString;
+        return isKolibriDate(date);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_kolibri_node_path.ts
+++ b/src/validation/decorators/is_kolibri_node_path.ts
@@ -27,12 +27,15 @@ import {
 } from 'class-validator';
 import { constants } from '../../common/constant';
 
+export function isKolibriNodePath(value: any) {
+    return isString(value) &&
+        length(value, 1, constants.DT_STRING_MAXLEN) &&
+        matches(value, /^\/(([a-z0-9][a-z0-9_.-]{0,30}\/?)*[a-z0-9])?$/i);
+}
 @ValidatorConstraint({ name: 'isKolibriNodePath', async: true })
 export class IsKolibriNodePathConstraint implements ValidatorConstraintInterface {
     validate(path: any, _args: ValidationArguments) {
-        return isString(path) &&
-            length(path, 1, constants.DT_STRING_MAXLEN) &&
-            matches(path, /^\/(([a-z0-9][a-z0-9_.-]{0,30}\/?)*[a-z0-9])?$/i);
+        return isKolibriNodePath(path);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_kolibri_project.ts
+++ b/src/validation/decorators/is_kolibri_project.ts
@@ -29,12 +29,16 @@ import { constants } from '../../common/constant';
 
 export const IS_KOLIBRI_PROJECT = 'isKolibriProject';
 
+export function isKolibriProject(value: any) {
+    return isString(value) &&
+        maxLength(value, constants.PROJECT_NAME_MAXLEN) &&
+        matches(value, /^(([a-z0-9])|([a-z0-9][a-z0-9-]{0,30}[a-z0-9]))$/i);
+}
+
 @ValidatorConstraint({ name: IS_KOLIBRI_PROJECT, async: true })
 export class IsKolibriProjectConstraint implements ValidatorConstraintInterface {
     validate(project: any, _args: ValidationArguments) {
-        return isString(project) &&
-            maxLength(project, constants.PROJECT_NAME_MAXLEN) &&
-            matches(project, /^(([a-z0-9])|([a-z0-9][a-z0-9-]{0,30}[a-z0-9]))$/i);
+        return isKolibriProject(project);
     }
 
     defaultMessage(_args: ValidationArguments) {
@@ -42,6 +46,7 @@ export class IsKolibriProjectConstraint implements ValidatorConstraintInterface 
         up to 32 characters from the character class [a-zA-Z0-9-]. It is case-insensitive.`;
     }
 }
+
 
 export function IsKolibriProject(validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {

--- a/src/validation/decorators/is_kolibri_trigger_n.ts
+++ b/src/validation/decorators/is_kolibri_trigger_n.ts
@@ -27,14 +27,18 @@ import {
 } from 'class-validator';
 
 
+export function isKolibriNodeTriggerN(value: any) {
+    if (!isBoolean(value) && !isString(value) && !isNumber(value)) {
+        return false;
+    }
+
+    return true;
+}
+
 @ValidatorConstraint({ name: 'isKolibriNodeTriggerN', async: true })
 export class IsKolibriNodeTriggerNConstraint implements ValidatorConstraintInterface {
     validate(triggerN: any, _args: ValidationArguments) {
-        if (!isBoolean(triggerN) && !isString(triggerN) && !isNumber(triggerN)) {
-            return false;
-        }
-
-        return true;
+        return isKolibriNodeTriggerN(triggerN);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_kolibri_trigger_n.ts
+++ b/src/validation/decorators/is_kolibri_trigger_n.ts
@@ -21,18 +21,12 @@ import {
     ValidatorConstraint,
     ValidatorConstraintInterface,
     ValidationArguments,
-    isBoolean,
-    isString,
     isNumber
 } from 'class-validator';
 
 
 export function isKolibriNodeTriggerN(value: any) {
-    if (!isBoolean(value) && !isString(value) && !isNumber(value)) {
-        return false;
-    }
-
-    return true;
+    return isNumber(value);
 }
 
 @ValidatorConstraint({ name: 'isKolibriNodeTriggerN', async: true })
@@ -42,7 +36,7 @@ export class IsKolibriNodeTriggerNConstraint implements ValidatorConstraintInter
     }
 
     defaultMessage(_args: ValidationArguments) {
-        return `TriggerT invalid`;
+        return `TriggerN invalid`;
     }
 }
 

--- a/src/validation/decorators/is_kolibri_trigger_t.ts
+++ b/src/validation/decorators/is_kolibri_trigger_t.ts
@@ -28,14 +28,18 @@ import {
 import { KolibriError, errorcode } from '../../common/errorcode';
 
 
+export function isKolibriNodeTriggerT(value: any) {
+    if (!isInt(value) || !min(value, 0) || !max(value, 4294967295)) {
+        throw new KolibriError(errorcode.INVALID_VALUE, 'triggerT invalid');
+    }
+
+    return true;
+}
+
 @ValidatorConstraint({ name: 'isKolibriNodeTriggerT', async: true })
 export class IsKolibriNodeTriggerTConstraint implements ValidatorConstraintInterface {
     validate(triggerT: any, _args: ValidationArguments) {
-        if (!isInt(triggerT) || !min(triggerT, 0) || !max(triggerT, 4294967295)) {
-            throw new KolibriError(errorcode.INVALID_VALUE, 'triggerT invalid');
-        }
-
-        return true;
+        return isKolibriNodeTriggerT(triggerT);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_kolibri_trigger_t.ts
+++ b/src/validation/decorators/is_kolibri_trigger_t.ts
@@ -25,11 +25,12 @@ import {
     min,
     max
 } from 'class-validator';
+import { constants } from '../../common/constant';
 import { KolibriError, errorcode } from '../../common/errorcode';
 
 
 export function isKolibriNodeTriggerT(value: any) {
-    if (!isInt(value) || !min(value, 0) || !max(value, 4294967295)) {
+    if (!isInt(value) || !min(value, 0) || !max(value, constants.DT_UINT_32BIT_MAX)) {
         throw new KolibriError(errorcode.INVALID_VALUE, 'triggerT invalid');
     }
 

--- a/src/validation/decorators/is_kolibri_update_url.ts
+++ b/src/validation/decorators/is_kolibri_update_url.ts
@@ -26,22 +26,26 @@ import {
 import Url from 'url-parse';
 import { constants } from '../../common/constant';
 
+export function isKolibriUpdateUrl(value: any) {
+    if (isString(value) &&
+        !(value.length > constants.DT_STRING_MAXLEN) &&
+        value !== '') {
+        const url = new Url(value);
+        if (url.protocol === 'https:' ||
+            url.protocol === 'http:' ||
+            url.host === null
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 
 @ValidatorConstraint({ name: 'isKolibriUpdateUrl', async: true })
 export class IsKolibriUpdateUrlConstraint implements ValidatorConstraintInterface {
     validate(updateUrl: any, _args: ValidationArguments) {
-        if (isString(updateUrl) &&
-            !(updateUrl.length > constants.DT_STRING_MAXLEN) &&
-            updateUrl !== '') {
-            const url = new Url(updateUrl);
-            if (url.protocol === 'https:' ||
-                url.protocol === 'http:' ||
-                url.host === null
-            ) {
-                return true;
-            }
-        }
-        return false;
+        return isKolibriUpdateUrl(updateUrl);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_kolibri_usergroup.ts
+++ b/src/validation/decorators/is_kolibri_usergroup.ts
@@ -29,12 +29,17 @@ import { constants } from '../../common/constant';
 
 export const IS_KOLIBRI_USER_GROUP = 'isKolibriUserGroup';
 
+
+export function isKolibriUserGroup(value: any) {
+    return isString(value) &&
+        maxLength(value, constants.USER_NAME_MAXLEN) &&
+        matches(value, /^(([a-z0-9])|([a-z0-9][a-z0-9_.-]{0,30}[a-z0-9]))$/i);
+}
+
 @ValidatorConstraint({ name: IS_KOLIBRI_USER_GROUP, async: true })
 export class IsKolibriUserGroupConstraint implements ValidatorConstraintInterface {
     validate(user: any, _args: ValidationArguments) {
-        return isString(user) &&
-            maxLength(user, constants.USER_NAME_MAXLEN) &&
-            matches(user, /^(([a-z0-9])|([a-z0-9][a-z0-9_.-]{0,30}[a-z0-9]))$/i);
+        return isKolibriUserGroup(user);
     }
 
     defaultMessage(_args: ValidationArguments) {

--- a/src/validation/decorators/is_unsigned_16_bit.ts
+++ b/src/validation/decorators/is_unsigned_16_bit.ts
@@ -25,11 +25,12 @@ import {
     min,
     max
 } from 'class-validator';
+import { constants } from '../../common/constant';
 
 export const IS_UNSIGNED_16_BIT = 'isUnsigned16Bit';
 
 export function isUnsigned16Bit(value: unknown): boolean {
-    return isInt(value) && min(value, 0) && max(value, 65535);
+    return isInt(value) && min(value, 0) && max(value, constants.DT_UINT_16BIT_MAX);
 }
 
 @ValidatorConstraint({ name: IS_UNSIGNED_16_BIT, async: true })


### PR DESCRIPTION
Extracted and exported validator functions to be reused in other places without decorators.